### PR TITLE
Added functionality to obtain circuit IDs

### DIFF
--- a/onion_proxy/circuit.py
+++ b/onion_proxy/circuit.py
@@ -13,12 +13,13 @@ class Circuit:
 	"""
 
 	@staticmethod
-	def get_rand_circ_id() -> int:
+	def get_rand_circ_id(current_circ_id: int) -> int:
 		"""
-		Returns a random circId for the circuit. Follows the Tor Spec to create the circId section 5.1.1
+		Returns a circId for the circuit. To prevent circId collisions, it increments the previous circId.
 		:return: circId --> integer
 		"""
-		return 1
+		circ_id = current_circ_id + 1
+		return circ_id
 
 	def __init__(self, node_container: List[Node], skt: Skt, circ_id: int):
 		"""

--- a/onion_proxy/main.py
+++ b/onion_proxy/main.py
@@ -7,6 +7,7 @@ from connection.skt import Skt
     This file will be run when the onion proxy is booted up
 """
 
+current_circ_id = 0
 
 # This function is the actual entry point that will be called
 def main():
@@ -14,7 +15,9 @@ def main():
 	skt = Skt('127.0.0.1', 4444)
 
 	print("Creating a circuit")
-	circ_id = Circuit.get_rand_circ_id()
+	global current_circ_id
+	circ_id = Circuit.get_rand_circ_id(current_circ_id)
+	current_circ_id += 1
 	node_container = NodeDirectoryService.get_rand_three_nodes()
 	circuit = Circuit(node_container, skt, circ_id)
 

--- a/onion_router/onion_router.py
+++ b/onion_router/onion_router.py
@@ -9,6 +9,8 @@ from crypto.core_crypto import CoreCryptoRSA
 
 class OnionRouter:
 
+    current_circ_id = 0
+
     def __init__(self, node=None, is_exit_node=True):
         self.node = node
         self.skt = Skt(node.host, node.port)
@@ -17,7 +19,8 @@ class OnionRouter:
         self.routing_table = {}
 
     def get_rand_circ_id(self) -> int:
-        return 1
+        self.current_circ_id += 1
+        return self.current_circ_id
 
     def listen(self):
         l = self.skt.server_listen()


### PR DESCRIPTION
### Design:

TOR specifications mention that using *random numbers* to achieve the functionality is the optimal method. This might be for security reasons. But for the scale of our implementation, generating circuit IDs by *incrementing a preset number* is a simpler and more effective way of avoiding circuit ID collisions.