### PR TITLE
Added functionality for creating and handling 'Extended2' relay cells

### DIFF
--- a/cell/relay_cell.py
+++ b/cell/relay_cell.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Any
+from crypto.core_crypto import CryptoConstants as CC
 
 class RelayCellPayload:
 
@@ -39,8 +40,22 @@ class RelayCellPayload:
         def reprJSON(self) -> Dict[str, Any]:
             return vars(self)
     
+class RelayExtendedPayload:
 
+    """
+    The class representing Extended Cell's payload object
+    """
 
+    TAP_S_HANDSHAKE_LEN = CC.DH_LEN + CC.HASH_LEN
 
+    def __init__(self, HLEN: int=None, HDATA=None):
+        """
+		Constructor
+		:param HLEN: The Length of the HDATA
+		:param HDATA: The actual Handshake data. Contains the first half of Diffie Hellman Handshake
+		"""
+		self.HLEN = HLEN
+		self.HDATA = HDATA
 
-
+    def reprJSON(self) -> Dict[str, Any]:
+		return vars(self)


### PR DESCRIPTION
### Changes:

- Added class RelayExtendedPayload to cell/relay_cell.py
- Added methods build_extended_cell(), parse_extended_cell() and process_extended_cell() in classes Builder, Parser and Processor respectively in cell/cell_processing.py.
- Fixed certain statements in 'created' cell handling functions in cell/cell_processing.py involving the function call to kdf_tor() in crypto/core_crypto.py

Finishes issue #19 